### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ npm install --save rc522-c7z
 ```
 var rc522 = require('rc522-c7z');
 
-rc522((serial) => {
-	console.log(serial);
+rc522.listen(serial => {
+  console.log(serial);
 });
 ```
 
@@ -72,7 +72,7 @@ rc522((serial) => {
 ```
 import rc522 from 'rc522-c7z';
 
-rc522((serial) => {
-	console.log(serial);
+rc522.listen(serial => {
+  console.log(serial);
 });
 ```

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ rc522.listen(serial => {
 
 ### For TypeScript
 ```
-import rc522 from 'rc522-c7z';
+import { listen } from 'rc522-c7z';
 
-rc522.listen(serial => {
+listen(serial => {
   console.log(serial);
 });
 ```


### PR DESCRIPTION
corrected the example code:
the exported function `listen` should be called